### PR TITLE
Bugfix/fs 1116 make upload params optional

### DIFF
--- a/filestack/trafarets.py
+++ b/filestack/trafarets.py
@@ -60,3 +60,5 @@ STORE_SCHEMA = t.Dict({
     'access': t.String(),
     'base64decode': t.Bool()
 })
+
+STORE_SCHEMA.make_optional('*')

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -32,7 +32,7 @@ def test_store(client):
         return response(200, {'url': 'https://cdn.filestackcontent.com/{}'.format(HANDLE)})
 
     with HTTMock(api_store):
-        filelink = client.upload(url="someurl")
+        filelink = client.upload(url="someurl", params={'filename': 'something.jpg'}, multipart=False)
 
     assert isinstance(filelink, Filelink)
     assert filelink.handle == HANDLE


### PR DESCRIPTION
Trafaret checks on upload parameters were previously all or nothing. This makes all parameters optional. 