### PR TITLE
Add headers to multipart uploads

### DIFF
--- a/examples/video_upload_and_conversion.py
+++ b/examples/video_upload_and_conversion.py
@@ -3,7 +3,7 @@ from filestack import Client
 client = Client('<YOUR_API_KEY')
 
 new_video = client.upload(filepath='/PATH/TO/FILE')
-new_video_conversion = new_video.av_convert(width=400,height=400)
+new_video_conversion = new_video.av_convert(width=400, height=400)
 
 while new_video_conversion.status != 'completed':
     print('not completed yet')

--- a/filestack/mixins/filestack_common.py
+++ b/filestack/mixins/filestack_common.py
@@ -7,6 +7,7 @@ from filestack.config import CDN_URL, API_URL, FILE_PATH
 from filestack.trafarets import CONTENT_DOWNLOAD_SCHEMA, OVERWRITE_SCHEMA
 from filestack.utils import utils
 
+
 class CommonMixin(object):
 
     def download(self, destination_path, params=None):

--- a/filestack/models/filestack_client.py
+++ b/filestack/models/filestack_client.py
@@ -19,7 +19,7 @@ class Client():
         self._storage = storage
 
     def transform_external(self, external_url):
-      return filestack.models.Transform(apikey=self.apikey, security=self.security, external_url=external_url)
+        return filestack.models.Transform(apikey=self.apikey, security=self.security, external_url=external_url)
 
     def urlscreenshot(self, external_url, agent=None, mode=None, width=None, height=None, delay=None):
         params = locals()
@@ -63,16 +63,16 @@ class Client():
 
             files, data = None, None
             if url:
-                  data = {'url': url}
+                data = {'url': url}
             if filepath:
-                  filename = os.path.basename(filepath)
-                  mimetype = mimetypes.guess_type(filepath)[0]
-                  files = {'fileUpload': (filename, open(filepath, 'rb'), mimetype)}
+                filename = os.path.basename(filepath)
+                mimetype = mimetypes.guess_type(filepath)[0]
+                files = {'fileUpload': (filename, open(filepath, 'rb'), mimetype)}
 
             if params:
-                  params['key'] = self.apikey
+                params['key'] = self.apikey
             else:
-                  params = {'key': self.apikey}
+                params = {'key': self.apikey}
 
             path = '{path}/{storage}'.format(path=STORE_PATH, storage=self.storage)
 
@@ -90,12 +90,12 @@ class Client():
 
     @property
     def security(self):
-      return self._security
+        return self._security
 
     @property
     def storage(self):
-      return self._storage
+        return self._storage
 
     @property
     def apikey(self):
-      return self._apikey
+        return self._apikey

--- a/filestack/utils/upload_utils.py
+++ b/filestack/utils/upload_utils.py
@@ -5,7 +5,10 @@ import hashlib
 import requests
 
 from base64 import b64encode
-from filestack.config import MULTIPART_START_URL, MULTIPART_UPLOAD_URL, MULTIPART_COMPLETE_URL, DEFAULT_CHUNK_SIZE
+from filestack.config import (
+    MULTIPART_START_URL, MULTIPART_UPLOAD_URL, MULTIPART_COMPLETE_URL,
+    DEFAULT_CHUNK_SIZE, HEADERS
+)
 from functools import partial
 from multiprocessing import Pool
 
@@ -27,7 +30,8 @@ def multipart_start(apikey, filename, filesize, mimetype, storage, params=None):
                 'size': filesize,
                 'store_location': storage
                 },
-            params=params
+            params=params,
+            headers=HEADERS
             )
     return response.json()
 
@@ -68,8 +72,12 @@ def upload_chunk(storage, job):
         'upload_id': job['upload_id'],
         'store_location': storage
     }
-
-    fs_resp = requests.post(MULTIPART_UPLOAD_URL, data=data, files={'file': (job['filename'], '', None)}).json()
+    fs_resp = requests.post(
+        MULTIPART_UPLOAD_URL,
+        data=data,
+        files={'file': (job['filename'], '', None)},
+        headers=HEADERS
+    ).json()
 
     resp = requests.put(fs_resp['url'], headers=fs_resp['headers'], data=chunk)
 
@@ -93,7 +101,8 @@ def multipart_complete(apikey, filename, filesize, mimetype, start_response, sto
         files={
             'file': (filename, '', None)
         },
-        params=params
+        params=params,
+        headers=HEADERS
     )
     return response
 

--- a/filestack/utils/upload_utils.py
+++ b/filestack/utils/upload_utils.py
@@ -22,17 +22,18 @@ def get_file_info(filepath, filename=None, mimetype=None):
 
 def multipart_start(apikey, filename, filesize, mimetype, storage, params=None):
     response = requests.post(
-            MULTIPART_START_URL, files={'file': (filename, '', None)},
-            data={
-                'apikey': apikey,
-                'filename': filename,
-                'mimetype': mimetype,
-                'size': filesize,
-                'store_location': storage
-                },
-            params=params,
-            headers=HEADERS
-            )
+        MULTIPART_START_URL,
+        files={'file': (filename, '', None)},
+        data={
+            'apikey': apikey,
+            'filename': filename,
+            'mimetype': mimetype,
+            'size': filesize,
+            'store_location': storage
+        },
+        params=params,
+        headers=HEADERS
+    )
     return response.json()
 
 


### PR DESCRIPTION
This PR adds `config.HEADERS` to each multipart upload requests that goes to Filestack servers.
`PUT` request to S3 is left untouched.

I also fixed some indentation issues.