### PR TITLE
fix security formatting for non-transform urls

### DIFF
--- a/filestack/mixins/filestack_common.py
+++ b/filestack/mixins/filestack_common.py
@@ -42,11 +42,13 @@ class CommonMixin(object):
 
 
     def get_metadata(self, params=None):
-        metadata_url = "{}/{}".format(self.url, METADATA_PATH)
+        metadata_url = "{CDN_URL}/{handle}/metadata".format(
+            CDN_URL=CDN_URL, handle=self.handle
+        )
         response = utils.make_call(metadata_url, 'get',
                                    params=params,
                                    security=self.security)
-        return response
+        return response.json()
 
 
     def delete(self, params=None):

--- a/tests/filelink_test.py
+++ b/tests/filelink_test.py
@@ -63,7 +63,7 @@ def test_get_metadata(filelink):
 
     with HTTMock(api_metadata):
         metadata_response = filelink.get_metadata()
-        metadata = metadata_response.json()
+        metadata = metadata_response
 
     assert metadata['filename'] == 'somefile.jpg'
 

--- a/tests/filelink_test.py
+++ b/tests/filelink_test.py
@@ -55,6 +55,14 @@ def test_get_content(filelink):
 
     assert content == b'SOMEBYTESCONTENT'
 
+def test_bad_call(filelink):
+    @urlmatch(netloc=r'cdn.filestackcontent\.com', method='get', scheme='https')
+    def api_bad(url, request):
+        return response(400, b'SOMEBYTESCONTENT')
+
+    with HTTMock(api_bad):
+        pytest.raises(Exception, filelink.get_content)
+
 
 def test_get_metadata(filelink):
     @urlmatch(netloc=r'cdn.filestackcontent.com', method='get', scheme='https')


### PR DESCRIPTION
This fixes an issue with URL security formatting that affected the delete() and overwrite() methods in the common mixin [FS-1365]. It also adds generic error handling to the make_call() utility function, so that any bad request raises and exception and reads out error message from Filestack API. 