### PR TITLE
add full response data to av_convert and related tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,24 @@ transform_candidate = client.transform_external('http://<SOME_URL>')
 transform = transform_candidate.resize(width=500, height=500).flip().enhance()
 print(transform.url)
 ```
-    
+
+### Audio/Video Convert
+
+Audio and video conversion works just like any transformation, except it returns an instance of class AudioVisual, which allows you to check the status of your video conversion, as well as get its UUID and timestamp. 
+
+```python
+av_object = filelink.av_convert(width=100, height=100)
+while (av_object.status != 'completed'):
+    print(av_object.status)
+    print(av_object.uuid)
+    print(av_object.timestamp)
+```
+The status property makes a call to the API to check its current status, and you can call to_filelink() once video is complete (this function checks its status first and will fail if not completed yet).
+
+```python
+filelink = av_object.to_filelink()
+```
+
 ### Security Objects
 
 Security is set on Client or Filelink classes upon instantiation.

--- a/filestack/mixins/filestack_imagetransform_mixin.py
+++ b/filestack/mixins/filestack_imagetransform_mixin.py
@@ -142,14 +142,16 @@ class ImageTransformationMixin(object):
 
         response = utils.make_call(transform_url, 'get')
 
-        if response.ok:
-            uuid = response.json()['uuid']
-            timestamp = response.json()['timestamp']
-            return filestack.models.AudioVisual(
-                transform_url, uuid, timestamp, apikey=new_transform.apikey, security=new_transform.security
-            )
+        if not response.ok:
+            raise Exception(response.text)
 
-        raise Exception(response.text)
+        uuid = response.json()['uuid']
+        timestamp = response.json()['timestamp']
+        
+        return filestack.models.AudioVisual(
+            transform_url, uuid, timestamp, apikey=new_transform.apikey, security=new_transform.security
+        )
+
 
     def add_transform_task(self, transformation, params):
 

--- a/filestack/mixins/filestack_imagetransform_mixin.py
+++ b/filestack/mixins/filestack_imagetransform_mixin.py
@@ -143,7 +143,11 @@ class ImageTransformationMixin(object):
         response = utils.make_call(transform_url, 'get')
 
         if response.ok:
-            return filestack.models.AudioVisual(transform_url, apikey=new_transform.apikey, security=new_transform.security)
+            uuid = response.json()['uuid']
+            timestamp = response.json()['timestamp']
+            return filestack.models.AudioVisual(
+                transform_url, uuid, timestamp, apikey=new_transform.apikey, security=new_transform.security
+            )
 
         raise Exception(response.text)
 

--- a/filestack/models/filestack_audiovisual.py
+++ b/filestack/models/filestack_audiovisual.py
@@ -7,10 +7,12 @@ from filestack.utils import utils
 
 class AudioVisual:
 
-    def __init__(self, url, apikey=None, security=None):
+    def __init__(self, url, uuid, timestamp, apikey=None, security=None):
         self._url = url
         self._apikey = apikey
         self._security = security
+        self._uuid = uuid
+        self._timestamp = timestamp
 
     def to_filelink(self):
         if self.status != 'completed':
@@ -44,3 +46,11 @@ class AudioVisual:
     @property
     def security(self):
         return self._security
+
+    @property
+    def uuid(self):
+        return self._uuid
+
+    @property
+    def timestamp(self):
+        return self._timestamp

--- a/filestack/utils/upload_utils.py
+++ b/filestack/utils/upload_utils.py
@@ -42,7 +42,7 @@ def multipart_start(apikey, filename, filesize, mimetype, storage, security=None
     )
 
     if not response.ok:
-        return response.text
+        raise Exception(response.text)
     
     return response.json()
 

--- a/filestack/utils/upload_utils.py
+++ b/filestack/utils/upload_utils.py
@@ -40,6 +40,10 @@ def multipart_start(apikey, filename, filesize, mimetype, storage, security=None
         params=params,
         headers=HEADERS
     )
+
+    if not response.ok:
+        return response.text
+    
     return response.json()
 
 

--- a/tests/audiovisual_test.py
+++ b/tests/audiovisual_test.py
@@ -13,8 +13,7 @@ PROCESS_URL = 'https://process.filestackapi.com/{}'.format(HANDLE)
 
 @pytest.fixture
 def av():
-    return AudioVisual(PROCESS_URL, apikey=APIKEY)
-
+    return AudioVisual(PROCESS_URL, 'someuuid', 'sometimetstamp', apikey=APIKEY)
 
 def test_status(av):
 
@@ -24,7 +23,6 @@ def test_status(av):
 
     with HTTMock(api_zip):
         assert av.status == 'completed'
-
 
 def test_convert(av):
 

--- a/tests/transform_test.py
+++ b/tests/transform_test.py
@@ -303,17 +303,19 @@ def test_store(transform):
     assert isinstance(store, Filelink)
 
 def test_av_convert(transform):
-    url = 'https://.com/{}'.format(HANDLE)
+    url = 'https://cdn.filestack.com/{}'.format(HANDLE)
     @urlmatch(netloc=r'process.filestackapi\.com', method='get', scheme='https')
     def av_convert(url, request):
-        return response(200, {'url': url})
+        return response(200, {'url': url, 'uuid': 'someuuid', 'timestamp': 'sometimestamp'})
 
     with HTTMock(av_convert):
         new_av = transform.av_convert(width=500, height=500)
         assert isinstance(new_av, AudioVisual)
+        assert new_av.uuid == 'someuuid'
+        assert new_av.timestamp == 'sometimestamp' 
 
 def test_debug(transform):
-    url = 'https://.com/{}'.format(HANDLE)
+    url = 'https://process.filestackapi.com/{}'.format(HANDLE)
     @urlmatch(netloc=r'cdn.filestackcontent\.com', method='get', scheme='https')
     def debug(url, request):
         return response(200, {'data': 'somedata'})


### PR DESCRIPTION
This adds feature FS-1364, adding uuid and timestamp to AudioVisual objects for better tracking. It was suggested in #20. 