### PR TITLE
Added code to close multipart pool after file upload

### DIFF
--- a/filestack/utils/upload_utils.py
+++ b/filestack/utils/upload_utils.py
@@ -142,5 +142,6 @@ def multipart_upload(apikey, filepath, storage, upload_processes=None, params=No
     pooling_job = partial(upload_chunk, storage)
     parts_and_etags = pool.map(pooling_job, jobs)
     file_data = multipart_complete(apikey, filename, filesize, mimetype, response_info, storage, parts_and_etags, params=params)
+    pool.close()
 
     return file_data


### PR DESCRIPTION
Shouldn't the multipart upload pool be closed after the file has been uploaded? When I was uploading many documents to filestack the code ended up using loads of memory as the processes were not being closed. 