### PR TITLE
Default upload mimetype

### DIFF
--- a/filestack/config.py
+++ b/filestack/config.py
@@ -19,6 +19,7 @@ HEADERS = {
 }
 
 DEFAULT_CHUNK_SIZE = 5 * 1024 ** 2
+DEFAULT_UPLOAD_MIMETYPE = 'application/octet-stream'
 
 STORE_PATH = 'store'
 FILE_PATH = 'file'

--- a/filestack/models/filestack_client.py
+++ b/filestack/models/filestack_client.py
@@ -13,8 +13,8 @@ from filestack.utils import intelligent_ingestion
 
 class Client():
     """
-    The hub for all Filestack operations. Creates Filelinks, converts external to transform objects, takes a URL screenshot and 
-    returns zipped files. 
+    The hub for all Filestack operations. Creates Filelinks, converts external to transform objects,
+    takes a URL screenshot and returns zipped files.
     """
     def __init__(self, apikey, security=None, storage='S3'):
         self._apikey = apikey
@@ -31,7 +31,7 @@ class Client():
         ```python
         from filestack import Client, Filelink
 
-        client = Client("API_KEY")    
+        client = Client("API_KEY")
         transform = client.transform_external('http://www.example.com')
         ```
         """
@@ -39,7 +39,7 @@ class Client():
 
     def urlscreenshot(self, external_url, agent=None, mode=None, width=None, height=None, delay=None):
         """
-        Takes a 'screenshot' of the given URL 
+        Takes a 'screenshot' of the given URL
 
         *returns* [Filestack.Transform]
 
@@ -94,8 +94,9 @@ class Client():
 
     def upload(self, url=None, filepath=None, multipart=True, params=None, upload_processes=None, intelligent=False):
         """
-        Uploads a file either through a local filepath or external_url. Uses multipart by default and Intelligent Ingestion by default (if enabled). You can specify the
-        number of multipart processes and pass in parameters.
+        Uploads a file either through a local filepath or external_url.
+        Uses multipart by default and Intelligent Ingestion by default (if enabled).
+        You can specify the number of multipart processes and pass in parameters.
 
         returns [Filestack.Filelink]
         ```python

--- a/filestack/models/filestack_filelink.py
+++ b/filestack/models/filestack_filelink.py
@@ -18,10 +18,10 @@ class Filelink(ImageTransformationMixin, CommonMixin):
 
     def tags(self):
         """
-        Get Google Vision tags for the Filelink. 
+        Get Google Vision tags for the Filelink.
 
         *returns* [Dict]
-        
+
         ```python
         from filestack import Client
 
@@ -34,7 +34,7 @@ class Filelink(ImageTransformationMixin, CommonMixin):
 
     def sfw(self):
         """
-        Get SFW label for the given file. 
+        Get SFW label for the given file.
 
         *returns* [Boolean]
 

--- a/filestack/models/filestack_security.py
+++ b/filestack/models/filestack_security.py
@@ -25,7 +25,7 @@ def validate(policy):
 
 def security(policy, app_secret):
     """
-    Creates a valid signature and policy based on provided app secret and 
+    Creates a valid signature and policy based on provided app secret and
     parameters
     ```python
     from filestack import Client, security

--- a/filestack/models/filestack_transform.py
+++ b/filestack/models/filestack_transform.py
@@ -137,7 +137,7 @@ class Transform(ImageTransformationMixin, CommonMixin):
 
     def debug(self):
         """
-        Returns a JSON object with inforamtion regarding the current transformation 
+        Returns a JSON object with inforamtion regarding the current transformation
 
         *returns* [Dict]
         """

--- a/filestack/utils/upload_utils.py
+++ b/filestack/utils/upload_utils.py
@@ -7,7 +7,7 @@ import requests
 from base64 import b64encode
 from filestack.config import (
     MULTIPART_START_URL, MULTIPART_UPLOAD_URL, MULTIPART_COMPLETE_URL,
-    DEFAULT_CHUNK_SIZE, HEADERS
+    DEFAULT_CHUNK_SIZE, DEFAULT_UPLOAD_MIMETYPE, HEADERS
 )
 from functools import partial
 from multiprocessing import Pool
@@ -16,7 +16,7 @@ from multiprocessing import Pool
 def get_file_info(filepath, filename=None, mimetype=None):
     filename = filename or os.path.split(filepath)[1]
     filesize = os.path.getsize(filepath)
-    mimetype = mimetype or mimetypes.guess_type(filepath)[0]
+    mimetype = mimetype or mimetypes.guess_type(filepath)[0] or DEFAULT_UPLOAD_MIMETYPE
     return filename, filesize, mimetype
 
 

--- a/filestack/utils/utils.py
+++ b/filestack/utils/utils.py
@@ -2,6 +2,7 @@ from filestack.config import CDN_URL, PROCESS_URL, HEADERS
 
 import requests
 
+
 def get_security_path(url, security):
     return '{url_path}?signature={signature}&policy={policy}'.format(
         url_path=url, policy=security['policy'].decode('utf-8'), signature=security['signature']
@@ -17,7 +18,7 @@ def get_url(base, handle=None, path=None, security=None):
     if handle:
         url_components.append(handle)
 
-    url_path =  '/'.join(url_components)
+    url_path = '/'.join(url_components)
 
     if security:
         return get_security_path(url_path, security)
@@ -36,11 +37,11 @@ def get_transform_url(tasks, external_url=None, handle=None, security=None, apik
         tasks.insert(0, 'debug')
 
     url_components.append('/'.join(tasks))
-    
+
     if security:
         url_components.append('security=policy:{},signature:{}'.format(
             security['policy'].decode('utf-8'), security['signature']))
-    
+
     url_components.append(handle or external_url)
 
     url_path = '/'.join(url_components)
@@ -58,8 +59,8 @@ def make_call(base, action, handle=None, path=None, params=None, data=None, file
 
     if not response.ok:
         raise Exception(response.text)
-        
-    return response 
+
+    return response
 
 
 def return_transform_task(transformation, params):

--- a/tests/audiovisual_test.py
+++ b/tests/audiovisual_test.py
@@ -1,4 +1,3 @@
-import filestack.models
 import pytest
 
 from filestack import AudioVisual, Filelink
@@ -15,6 +14,7 @@ PROCESS_URL = 'https://process.filestackapi.com/{}'.format(HANDLE)
 def av():
     return AudioVisual(PROCESS_URL, 'someuuid', 'sometimetstamp', apikey=APIKEY)
 
+
 def test_status(av):
 
     @urlmatch(netloc=r'process.filestackapi\.com', method='get', scheme='https')
@@ -23,6 +23,7 @@ def test_status(av):
 
     with HTTMock(api_zip):
         assert av.status == 'completed'
+
 
 def test_convert(av):
 

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -3,7 +3,6 @@ import pytest
 
 from base64 import b64encode
 from filestack import Client, Filelink, Transform
-from filestack.exceptions import FilestackException
 from httmock import urlmatch, HTTMock, response
 from trafaret import DataError
 
@@ -37,6 +36,7 @@ def test_store(client):
     assert isinstance(filelink, Filelink)
     assert filelink.handle == HANDLE
 
+
 def test_store_filepath(client):
     @urlmatch(netloc=r'www\.filestackapi\.com', path='/api/store', method='post', scheme='https')
     def api_store(url, request):
@@ -47,6 +47,7 @@ def test_store_filepath(client):
 
     assert isinstance(filelink, Filelink)
     assert filelink.handle == HANDLE
+
 
 def test_wrong_store_params(client):
     kwargs = {'params': {'call': 'someparameter'}, 'url': 'someurl'}

--- a/tests/filelink_test.py
+++ b/tests/filelink_test.py
@@ -8,13 +8,13 @@ from trafaret import DataError
 
 APIKEY = 'APIKEY'
 HANDLE = 'SOMEHANDLE'
+SECURITY = security({'call': ['read'], 'expiry': 10238239}, 'APPSECRET')
 
 
 @pytest.fixture
 def filelink():
     return Filelink(HANDLE, apikey=APIKEY)
 
-SECURITY = security({'call': ['read'], 'expiry': 10238239}, 'APPSECRET')
 
 @pytest.fixture
 def secure_filelink():
@@ -54,6 +54,7 @@ def test_get_content(filelink):
         content = filelink.get_content()
 
     assert content == b'SOMEBYTESCONTENT'
+
 
 def test_bad_call(filelink):
     @urlmatch(netloc=r'cdn.filestackcontent\.com', method='get', scheme='https')
@@ -128,6 +129,7 @@ def test_download(filelink):
         download_response = filelink.download('tests/data/test_download.jpg')
         assert download_response.status_code == 200
 
+
 def test_overwrite_content(secure_filelink):
     @urlmatch(netloc=r'www\.filestackapi\.com', path='/api/file', method='post', scheme='https')
     def api_delete(url, request):
@@ -164,6 +166,7 @@ def test_overwrite_bad_param_value(secure_filelink):
     kwargs = {'params': {'base64decode': 'true'}}
     pytest.raises(DataError, secure_filelink.overwrite, **kwargs)
 
+
 def test_tags(secure_filelink):
     @urlmatch(netloc=r'cdn.filestackcontent.com', method='get', scheme='https')
     def tag_request(url, request):
@@ -172,6 +175,7 @@ def test_tags(secure_filelink):
     with HTTMock(tag_request):
         tag_response = secure_filelink.tags()
         assert tag_response['tags']['auto']['tag'] == 100
+
 
 def test_unsecure_tags(filelink):
     pytest.raises(Exception, filelink.tags)

--- a/tests/intelligent_ingestion_test.py
+++ b/tests/intelligent_ingestion_test.py
@@ -5,7 +5,7 @@ from queue import Empty as QueueEmptyException
 from multiprocessing import Process, Queue
 
 import pytest
-from httmock import urlmatch, HTTMock, all_requests
+from httmock import urlmatch, HTTMock
 
 from filestack.utils.intelligent_ingestion import (
     UploadManager,
@@ -25,6 +25,7 @@ def upload_manager():
         params=None, security=None,
         upload_q=Queue(), commit_q=Queue(), response_q=Queue()
     )
+
 
 @urlmatch(netloc=r'upload\.filestackapi\.com', path='/multipart/start', method='post', scheme='https')
 def multipart_start_mock(url, request):
@@ -370,5 +371,5 @@ def test_manage_upload_process():
 def test_whole_upload():
     with HTTMock(multipart_start_mock), HTTMock(multipart_complete_mock), HTTMock(multipart_commit_mock), \
          HTTMock(fs_backend_mock), HTTMock(s3_mock):
-         response = upload('Apikeyz', 'tests/data/doom.mp4', 's3')
+        response = upload('Apikeyz', 'tests/data/doom.mp4', 's3')
     assert response.json()['msg'] == 'ok'

--- a/tests/transform_test.py
+++ b/tests/transform_test.py
@@ -302,8 +302,8 @@ def test_store(transform):
 
     assert isinstance(store, Filelink)
 
+
 def test_av_convert(transform):
-    url = 'https://cdn.filestack.com/{}'.format(HANDLE)
     @urlmatch(netloc=r'process.filestackapi\.com', method='get', scheme='https')
     def av_convert(url, request):
         return response(200, {'url': url, 'uuid': 'someuuid', 'timestamp': 'sometimestamp'})
@@ -312,10 +312,10 @@ def test_av_convert(transform):
         new_av = transform.av_convert(width=500, height=500)
         assert isinstance(new_av, AudioVisual)
         assert new_av.uuid == 'someuuid'
-        assert new_av.timestamp == 'sometimestamp' 
+        assert new_av.timestamp == 'sometimestamp'
+
 
 def test_debug(transform):
-    url = 'https://process.filestackapi.com/{}'.format(HANDLE)
     @urlmatch(netloc=r'cdn.filestackcontent\.com', method='get', scheme='https')
     def debug(url, request):
         return response(200, {'data': 'somedata'})


### PR DESCRIPTION
When no mimetype is specified and uploaded file has no extension, a default mimetype is needed for multipart upload.

For now it will be set to `'application/octet-stream'`

This should solve https://github.com/filestack/filestack-python/issues/27