### PR TITLE
Use store params in multipart uploads

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 
 python:
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"

--- a/filestack/utils/upload_utils.py
+++ b/filestack/utils/upload_utils.py
@@ -27,8 +27,7 @@ def multipart_start(apikey, filename, filesize, mimetype, storage, security=None
         'filename': filename,
         'mimetype': mimetype,
         'size': filesize,
-        'store_location': storage,
-        'store_region': 'what'
+        'store_location': storage
     }
 
     if params:

--- a/filestack/utils/utils.py
+++ b/filestack/utils/utils.py
@@ -9,6 +9,13 @@ def get_security_path(url, security):
     )
 
 
+def store_params(params):
+    return {
+        'store_{}'.format(key): value for key, value in params.items()
+        if key in ('path', 'location', 'region', 'container', 'access')
+    }
+
+
 def get_url(base, handle=None, path=None, security=None):
     url_components = [base]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,2 @@
-coveralls==1.1
-future==0.16.0
-httmock==1.2.6
-magicmock==0.3
-mock==2.0.0
-pylint==1.7.1
-pytest==3.0.7
-pytest-cov==2.5.0
-requests==2.13.0
-requests-mock==1.3.0
-responses==0.5.1
-trafaret==0.9.0
-unittest2==1.1.0
+requests==2.21.0
+trafaret==1.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,13 @@
+coveralls==1.1
+future==0.16.0
+httmock==1.2.6
+magicmock==0.3
+mock==2.0.0
+pylint==1.7.1
+pytest==3.0.7
+pytest-cov==2.5.0
 requests==2.21.0
+requests-mock==1.3.0
+responses==0.5.1
 trafaret==1.2.0
+unittest2==1.1.0

--- a/tests/intelligent_ingestion_test.py
+++ b/tests/intelligent_ingestion_test.py
@@ -1,6 +1,9 @@
 import json
 from collections import defaultdict
-from queue import Empty as QueueEmptyException
+try:
+    from queue import Empty as QueueEmptyException
+except ImportError:
+    from Queue import Empty as QueueEmptyException
 
 from multiprocessing import Process, Queue
 


### PR DESCRIPTION
For new uploads, store params should be passed as `data`.