### PR TITLE
Encode external urls

### DIFF
--- a/filestack/uploads/external_url.py
+++ b/filestack/uploads/external_url.py
@@ -1,3 +1,4 @@
+import base64
 from collections import OrderedDict
 
 from filestack.utils import requests
@@ -24,7 +25,8 @@ def build_store_task(store_params):
 
 def upload_external_url(url, apikey, store_params=None, security=None):
     store_task = build_store_task(store_params or {})
-    url_elements = [config.CDN_URL, apikey, store_task, url]
+    encoded_url = 'b64://{}'.format(base64.b64encode(url.encode()).decode())
+    url_elements = [config.CDN_URL, apikey, store_task, encoded_url]
 
     if security is not None:
         url_elements.insert(3, security.as_url_string())

--- a/filestack/uploads/external_url.py
+++ b/filestack/uploads/external_url.py
@@ -25,7 +25,7 @@ def build_store_task(store_params):
 
 def upload_external_url(url, apikey, store_params=None, security=None):
     store_task = build_store_task(store_params or {})
-    encoded_url = 'b64://{}'.format(base64.b64encode(url.encode()).decode())
+    encoded_url = 'b64://{}'.format(base64.urlsafe_b64encode(url.encode()).decode())
     url_elements = [config.CDN_URL, apikey, store_task, encoded_url]
 
     if security is not None:

--- a/tests/uploads/test_upload_external_url.py
+++ b/tests/uploads/test_upload_external_url.py
@@ -1,3 +1,4 @@
+import base64
 from unittest.mock import patch
 
 import pytest
@@ -8,6 +9,7 @@ from filestack.models import Security
 from filestack.uploads.external_url import upload_external_url
 
 url = 'http://image.url'
+encoded_url = 'b64://{}'.format(base64.b64encode(url.encode()).decode())
 apikey = 'TESTAPIKEY'
 
 
@@ -17,7 +19,7 @@ def test_upload(post_mock):
 
     handle = upload_external_url(url, apikey)
     assert handle == 'newHandle'
-    post_mock.assert_called_once_with('{}/{}/store/{}'.format(config.CDN_URL, apikey, url))
+    post_mock.assert_called_once_with('{}/{}/store/{}'.format(config.CDN_URL, apikey, encoded_url))
 
 
 @pytest.mark.parametrize('store_params, expected_store_task', [
@@ -47,7 +49,7 @@ def test_upload_with_security(post_mock):
     handle = upload_external_url(url, apikey, security=security)
     assert handle == 'newHandle'
     expected_url = '{}/{}/store/{}/{}'.format(
-        config.CDN_URL, apikey, security.as_url_string(), url
+        config.CDN_URL, apikey, security.as_url_string(), encoded_url
     )
     post_mock.assert_called_once_with(expected_url)
 

--- a/tests/uploads/test_upload_external_url.py
+++ b/tests/uploads/test_upload_external_url.py
@@ -9,7 +9,7 @@ from filestack.models import Security
 from filestack.uploads.external_url import upload_external_url
 
 url = 'http://image.url'
-encoded_url = 'b64://{}'.format(base64.b64encode(url.encode()).decode())
+encoded_url = 'b64://{}'.format(base64.urlsafe_b64encode(url.encode()).decode())
 apikey = 'TESTAPIKEY'
 
 


### PR DESCRIPTION
Use URL safe base64 encoding when uploading external urls.