### PR TITLE
Deprecate raising `Exception` in favour of requests `HTTPError`

### DIFF
--- a/filestack/exceptions.py
+++ b/filestack/exceptions.py
@@ -1,0 +1,7 @@
+class FilestackHTTPError(Exception):
+    """
+    Custom HTTPError instead of requests.exceptions.HTTPError to add response body.
+
+    References:
+        - https://github.com/psf/requests/pull/4234
+    """

--- a/filestack/utils.py
+++ b/filestack/utils.py
@@ -3,8 +3,10 @@ import string
 import random
 from functools import partial
 import requests as original_requests
+from requests.exceptions import HTTPError
 
 from filestack import config
+from filestack.exceptions import FilestackHTTPError
 
 
 def unique_id(length=10):
@@ -30,8 +32,10 @@ class RequestsWrapper:
         requests_method = getattr(original_requests, name)
         response = requests_method(*args, **kwargs)
 
-        if not response.ok:
-            raise Exception(response.text)
+        try:
+            response.raise_for_status()
+        except HTTPError as e:
+            raise FilestackHTTPError(response.text) from e
 
         return response
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,3 +1,4 @@
+from requests.exceptions import HTTPError
 
 
 class DummyHttpResponse:
@@ -11,3 +12,12 @@ class DummyHttpResponse:
 
     def json(self):
         return self.json_dict
+
+    def raise_for_status(self):
+        """
+        Return a dummy error if 'ok' was specified as False.
+
+        Note that in the original 'requests', response.ok calls raise_for_status() instead
+        """
+        if not self.ok:
+            raise HTTPError("HTTP request failed.")


### PR DESCRIPTION
Raising the base Exception class makes it difficult to catch this exception outside the SDK without catching a broad exception everywhere. i.e. `except Exception`
This will suppress all kinds of exceptions, aside from just Filestack ones. With this PR code that uses the Filestack SDK can catch HTTPError or any exceptions thrown by the requests library, and not need a broad catch-all.

Infact `response.ok` itself calls `raise_for_status()`. See [here](https://2.python-requests.org/en/master/_modules/requests/models/#Response.raise_for_status) _search for `def ok`_

```python
  @property
  def ok(self):
        """Returns True if :attr:`status_code` is less than 400, False if not.

        This attribute checks if the status code of the response is between
        400 and 600 to see if there was a client error or a server error. If
        the status code is between 200 and 400, this will return True. This
        is **not** a check to see if the response code is ``200 OK``.
        """
        try:
            self.raise_for_status()
        except HTTPError:
            return False
        return True
```

If this has other side effects, then Filestack should define their own exception class instead of re-using `Exception`, so it can be caught by the calling code. Let me know if that  works and i will update the PR.