### PR TITLE
Update the requests dependency version

### DIFF
--- a/filestack/__init__.py
+++ b/filestack/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '3.2.1'
+__version__ = '3.2.2'
 
 
 class CFG:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ coveralls==1.1
 httmock==1.2.6
 pytest==4.6.3
 pytest-cov==2.5.0
-requests==2.24.0
+requests==2.25.1
 responses==0.10.6
 trafaret==2.0.2

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     author_email='support@filestack.com',
     packages=find_packages(),
     install_requires=[
-        'requests==2.24.0',
+        'requests==2.25.1',
         'trafaret==2.0.2'
     ],
     classifiers=[


### PR DESCRIPTION
Update the requests dependency to the latest version. In production, other dependency uses latest version of requests and because of filestack, we're unable to use the latest version of another library.