### PR TITLE
Broaden pinned requests dependency version to '>=2.25.1'

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
 Sphinx==2.1.2
 sphinx-rtd-theme==0.4.3
 trafaret==2.0.2
-requests==2.24.0
+requests>=2.25.1

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     author_email='support@filestack.com',
     packages=find_packages(),
     install_requires=[
-        'requests==2.25.1',
+        'requests>=2.25.1',
         'trafaret==2.0.2'
     ],
     classifiers=[


### PR DESCRIPTION
- Broaden pinned requests version from 2.24.0 to >=2.25.1
- Also update pinned requests in doc/requirements.txt


## Notes
- [`requests` Release Notes](https://docs.python-requests.org/en/master/community/updates/)
- The current version on pypi for requests is `2.26.0`
- This will allow projects using Filestack as a dependency to not be restricted to a specific pinned version, but also allow slightly older versions like the current 2.25.1. 

Question:  _Perhaps it should be even broader like `>=2.23.0` . Since I added the updated pinned version in a PR [here](https://github.com/filestack/filestack-python/pull/51). There don't seem to have been any breaking changes since 2.23 even._
